### PR TITLE
test: clang needs -fbracket-depth

### DIFF
--- a/test/lang_c_test.py
+++ b/test/lang_c_test.py
@@ -8,9 +8,21 @@ class LinuxTestCase(backend.BackendTestCase):
     BACKEND_PATH = "lang_c/backend.b"
     BACKEND_INDEX = 2
 
+    cc_flags = []
+
+    def __init__(self, *args, **kwargs):
+        super(LinuxTestCase, self).__init__(*args, **kwargs)
+
+        p = subprocess.Popen(['gcc', '-v'], stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        self.assertEquals(p.returncode, 0)
+
+        if "clang" in stderr.decode("utf-8"):
+            self.cc_flags = ["-fbracket-depth=512"]
+
     def run_program(self, path, input):
         os.rename(path, path + ".c")
-        subprocess.call(['gcc', path + ".c", '-o', path])
+        subprocess.call(['gcc', path + ".c", '-o', path] + self.cc_flags)
         p = subprocess.Popen([path],
                              stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE)


### PR DESCRIPTION
The test with deep nested loops fails with clang unless we pass -fbracket-depth